### PR TITLE
Added a set of extensions that enhance error handling presentation.

### DIFF
--- a/RSCore.xcodeproj/project.pbxproj
+++ b/RSCore.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		51C4506F225FF23B00C03939 /* RSScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C4506D225FF23B00C03939 /* RSScreen.swift */; };
 		51C45071225FF25800C03939 /* RSImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C45070225FF25800C03939 /* RSImage.swift */; };
 		51C45072225FF25800C03939 /* RSImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C45070225FF25800C03939 /* RSImage.swift */; };
+		51C452242264E22B00C03939 /* UIWindow-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452212264E22A00C03939 /* UIWindow-Extensions.swift */; };
+		51C452252264E22B00C03939 /* UIViewController-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452222264E22A00C03939 /* UIViewController-Extensions.swift */; };
+		51C452262264E22B00C03939 /* UIApplication-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452232264E22B00C03939 /* UIApplication-Extensions.swift */; };
 		65CF4DE62135D5BE00F7DB67 /* RSDarkModeAdaptingToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CF4DE52135D5BE00F7DB67 /* RSDarkModeAdaptingToolbarButton.swift */; };
 		65CF4E1B2135D74500F7DB67 /* NSAppearance+RSCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CF4E1A2135D74500F7DB67 /* NSAppearance+RSCore.swift */; };
 		8402047E1FBCE77900D94C1A /* BatchUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8402047D1FBCE77900D94C1A /* BatchUpdate.swift */; };
@@ -198,6 +201,9 @@
 		51C4506A225FF22100C03939 /* UniqueIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UniqueIdentifier.swift; path = RSCore/UniqueIdentifier.swift; sourceTree = "<group>"; };
 		51C4506D225FF23B00C03939 /* RSScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RSScreen.swift; path = RSCore/RSScreen.swift; sourceTree = "<group>"; };
 		51C45070225FF25800C03939 /* RSImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RSImage.swift; path = RSCore/RSImage.swift; sourceTree = "<group>"; };
+		51C452212264E22A00C03939 /* UIWindow-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWindow-Extensions.swift"; sourceTree = "<group>"; };
+		51C452222264E22A00C03939 /* UIViewController-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController-Extensions.swift"; sourceTree = "<group>"; };
+		51C452232264E22B00C03939 /* UIApplication-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication-Extensions.swift"; sourceTree = "<group>"; };
 		65CF4DE52135D5BE00F7DB67 /* RSDarkModeAdaptingToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDarkModeAdaptingToolbarButton.swift; sourceTree = "<group>"; };
 		65CF4E1A2135D74500F7DB67 /* NSAppearance+RSCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAppearance+RSCore.swift"; sourceTree = "<group>"; };
 		8402047D1FBCE77900D94C1A /* BatchUpdate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BatchUpdate.swift; path = RSCore/BatchUpdate.swift; sourceTree = "<group>"; };
@@ -352,6 +358,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		51C452202264E20700C03939 /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				51C452232264E22B00C03939 /* UIApplication-Extensions.swift */,
+				51C452222264E22A00C03939 /* UIViewController-Extensions.swift */,
+				51C452212264E22A00C03939 /* UIWindow-Extensions.swift */,
+			);
+			path = UIKit;
+			sourceTree = "<group>";
+		};
 		842DD7BD1E14993900E061EB /* RSCoreiOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -403,6 +419,7 @@
 				51C4506D225FF23B00C03939 /* RSScreen.swift */,
 				84CFF5241AC3C8A200CEA6C8 /* Foundation */,
 				84CFF5551AC3CF4A00CEA6C8 /* AppKit */,
+				51C452202264E20700C03939 /* UIKit */,
 				84CFF5661AC3D13F00CEA6C8 /* Images */,
 				84CFF4F81AC3C69700CEA6C8 /* Info.plist */,
 				84CFF5031AC3C69700CEA6C8 /* RSCoreTests */,
@@ -780,6 +797,7 @@
 				84B99C9B1FAE650100ECDEDB /* OPMLRepresentable.swift in Sources */,
 				842DD7D71E14996300E061EB /* NSArray+RSCore.m in Sources */,
 				842DD7F31E14996B00E061EB /* NSMutableDictionary-Extensions.swift in Sources */,
+				51C452242264E22B00C03939 /* UIWindow-Extensions.swift in Sources */,
 				840F7BFA21AD05560057E851 /* String+RSCore.swift in Sources */,
 				842DD7DF1E14996300E061EB /* NSDictionary+RSCore.m in Sources */,
 				842DD7C81E14995C00E061EB /* RSConstants.m in Sources */,
@@ -805,10 +823,12 @@
 				51C4506F225FF23B00C03939 /* RSScreen.swift in Sources */,
 				842DD7F21E14996B00E061EB /* Date+Extensions.swift in Sources */,
 				842DD7ED1E14996300E061EB /* NSSet+RSCore.m in Sources */,
+				51C452252264E22B00C03939 /* UIViewController-Extensions.swift in Sources */,
 				84C687361FBC025600345C9E /* Log.swift in Sources */,
 				842DD7CA1E14995C00E061EB /* RSPlatform.m in Sources */,
 				842DD7D91E14996300E061EB /* NSCalendar+RSCore.m in Sources */,
 				842DD7F11E14996300E061EB /* NSTimer+RSCore.m in Sources */,
+				51C452262264E22B00C03939 /* UIApplication-Extensions.swift in Sources */,
 				842DD7F61E14997600E061EB /* RSImageRenderer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/UIKit/UIApplication-Extensions.swift
+++ b/UIKit/UIApplication-Extensions.swift
@@ -1,0 +1,20 @@
+//
+//  UIViewController+.swift
+//  NetNewsWire
+//
+//  Created by Maurice Parker on 4/15/19.
+//  Copyright © 2019 Ranchero Software. All rights reserved.
+//
+
+import UIKit
+
+extension UIApplication {
+	
+	func presentError(_ error: Error) {
+		guard let controller = windows.first?.topViewController else {
+			return
+		}
+		controller.presentError(error)
+	}
+	
+}

--- a/UIKit/UIViewController-Extensions.swift
+++ b/UIKit/UIViewController-Extensions.swift
@@ -1,0 +1,25 @@
+//
+//  UIViewController+.swift
+//  NetNewsWire
+//
+//  Created by Maurice Parker on 4/15/19.
+//  Copyright © 2019 Ranchero Software. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+	
+	func presentError(_ error: Error) {
+		let errorTitle = NSLocalizedString("Error", comment: "Error")
+		presentError(title: errorTitle, message: error.localizedDescription)
+	}
+	
+	func presentError(title: String, message: String) {
+		let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+		let dismissTitle = NSLocalizedString("Dismiss", comment: "Dismiss")
+		alertController.addAction(UIAlertAction(title: dismissTitle, style: .default))
+		self.present(alertController, animated: true, completion: nil)
+	}
+	
+}

--- a/UIKit/UIWindow-Extensions.swift
+++ b/UIKit/UIWindow-Extensions.swift
@@ -1,0 +1,41 @@
+//
+//  UIViewController+.swift
+//  NetNewsWire
+//
+//  Created by Maurice Parker on 4/15/19.
+//  Copyright © 2019 Ranchero Software. All rights reserved.
+//
+
+import UIKit
+
+extension UIWindow {
+	
+	var topViewController: UIViewController? {
+		
+		var top = self.rootViewController
+		while true {
+			if let presented = top?.presentedViewController {
+				top = presented
+			} else if let nav = top as? UINavigationController {
+				top = nav.visibleViewController
+			} else if let tab = top as? UITabBarController {
+				top = tab.selectedViewController
+			} else if let split = top as? UISplitViewController {
+				switch split.displayMode {
+				case .allVisible:
+					top = split.viewControllers.first
+				case .primaryHidden:
+					top = split.viewControllers.last
+				default:
+					top = split.viewControllers.first
+				}
+			} else {
+				break
+			}
+		}
+		
+		return top
+		
+	}
+	
+}


### PR DESCRIPTION
I need these extensions to make the Account class work on iOS.  It does a NSApplication.shared.presentError call that I needed the equivalent for on iOS.  These extensions make it possible to do UIApplication.shared.presentError.