### PR TITLE
Fix detection of IPv6 addresses

### DIFF
--- a/RSCore/NSString+RSCore.m
+++ b/RSCore/NSString+RSCore.m
@@ -96,7 +96,7 @@ NSString *RSStringReplaceAll(NSString *stringToSearch, NSString *searchFor, NSSt
 		return NO;
 	}
 
-	if (![s containsString:@"."]) {
+	if (![s containsString:@"."] && ![s containsString:@":"]) { // ":" is for IPv6
 		return NO;
 	}
 

--- a/RSCore/NSString+RSCore.m
+++ b/RSCore/NSString+RSCore.m
@@ -89,6 +89,11 @@ NSString *RSStringReplaceAll(NSString *stringToSearch, NSString *searchFor, NSSt
 	return range.length > 0;
 }
 
+- (BOOL)rs_stringMayBeIPv6URL {
+
+	return [self rangeOfString:@"\\[[0-9a-fA-F:]+\\]" options:NSRegularExpressionSearch].location != NSNotFound;
+}
+
 - (BOOL)rs_stringMayBeURL {
 
 	NSString *s = [self rs_stringByTrimmingWhitespace];
@@ -96,7 +101,7 @@ NSString *RSStringReplaceAll(NSString *stringToSearch, NSString *searchFor, NSSt
 		return NO;
 	}
 
-	if (![s containsString:@"."] && ![s containsString:@":"]) { // ":" is for IPv6
+	if (![s containsString:@"."] && ![s rs_stringMayBeIPv6URL]) {
 		return NO;
 	}
 


### PR DESCRIPTION
Fixes brentsimmons/NetNewsWire#1382.

This will allow `http://` without anything else, but that's better than not allowing IPv6 addresses.