### PR TITLE
Revise OPMLRepresentable

### DIFF
--- a/RSCore/OPMLRepresentable.swift
+++ b/RSCore/OPMLRepresentable.swift
@@ -10,5 +10,12 @@ import Foundation
 
 public protocol OPMLRepresentable {
 
-	func OPMLString(indentLevel: Int, strictConformance: Bool) -> String
+	func OPMLString(indentLevel: Int, allowsCustomAttributes: Bool) -> String
+}
+
+public extension OPMLRepresentable {
+
+	func OPMLString(indentLevel: Int) -> String {
+		return OPMLString(indentLevel: indentLevel, allowsCustomAttributes: false)
+	}
 }

--- a/RSCore/OPMLRepresentable.swift
+++ b/RSCore/OPMLRepresentable.swift
@@ -10,12 +10,12 @@ import Foundation
 
 public protocol OPMLRepresentable {
 
-	func OPMLString(indentLevel: Int, allowsCustomAttributes: Bool) -> String
+	func OPMLString(indentLevel: Int, allowCustomAttributes: Bool) -> String
 }
 
 public extension OPMLRepresentable {
 
 	func OPMLString(indentLevel: Int) -> String {
-		return OPMLString(indentLevel: indentLevel, allowsCustomAttributes: false)
+		return OPMLString(indentLevel: indentLevel, allowCustomAttributes: false)
 	}
 }


### PR DESCRIPTION
Fixes #30.

Protocol methods can't have default arguments, but that's easily workaroundable with an extension.