### PR TITLE
Image detection rework

### DIFF
--- a/RSCore/Data+RSCore.swift
+++ b/RSCore/Data+RSCore.swift
@@ -54,21 +54,23 @@ public extension Data {
 		/// The signature for GIF 89a data.
 		///
 		/// [http://www.onicos.com/staff/iz/formats/gif.html](http://www.onicos.com/staff/iz/formats/gif.html)
-		static let gif89a = "GIF89a".data(using: .ascii)
+		static let gif89a = "GIF89a".data(using: .ascii)!
 		/// The signature for GIF 87a data.
 		///
 		/// [http://www.onicos.com/staff/iz/formats/gif.html](http://www.onicos.com/staff/iz/formats/gif.html)
-		static let gif87a = "GIF87a".data(using: .ascii)
+		static let gif87a = "GIF87a".data(using: .ascii)!
+
 
 		/// The signature for standard JPEG data.
 		///
 		/// JPEG signatures start at byte 6.
-		static let jfif = "JFIF".data(using: .ascii)
+		static let jfif = "JFIF".data(using: .ascii)!
 
 		/// The signature for Exif JPEG data.
 		///
 		/// JPEG signatures start at byte 6.
-		static let exif = "Exif".data(using: .ascii)
+		static let exif = "Exif".data(using: .ascii)!
+
 	}
 
 	/// Returns `true` if the data begins with the PNG signature.

--- a/RSCore/Data+RSCore.swift
+++ b/RSCore/Data+RSCore.swift
@@ -66,17 +66,13 @@ public extension Data {
 
 	}
 
-	/// Check if data matches a signature at a particular offset.
+	/// Check if data matches a signature at its start.
 	///
-	/// - Parameters:
-	///   - signatures: An array of signatures to match against.
-	///   - offset: The offset into `self` to check for a match.
+	/// - Parameter signatures: An array of signatures to match against.
 	/// - Returns: `true` if the data matches; `false` otherwise.
 	private func matchesSignature(from signatures: [Data]) -> Bool {
 		for signature in signatures {
-			let upperBound = signature.count
-
-			if upperBound < count, self[..<upperBound] == signature {
+			if self.prefix(signature.count) == signature {
 				return true
 			}
 		}

--- a/RSCore/Data+RSCore.swift
+++ b/RSCore/Data+RSCore.swift
@@ -77,6 +77,12 @@ public extension Data {
 		static let jpeg = [Self.jfif, Self.exif]
 	}
 
+	/// Check if data matches a signature at a particular offset.
+	///
+	/// - Parameters:
+	///   - signatures: An array of signatures to match against.
+	///   - offset: The offset into `self` to check for a match.
+	/// - Returns: `true` if the data matches; `false` otherwise.
 	private func matchesSignature(from signatures: [Data], at offset: Int = 0) -> Bool {
 		for signature in signatures {
 			let upperBound = signature.count + offset

--- a/RSCore/Data+RSCore.swift
+++ b/RSCore/Data+RSCore.swift
@@ -60,6 +60,8 @@ public extension Data {
 		/// [http://www.onicos.com/staff/iz/formats/gif.html](http://www.onicos.com/staff/iz/formats/gif.html)
 		static let gif87a = "GIF87a".data(using: .ascii)!
 
+		/// A convenience array of all GIF signatures.
+		static let gif = [Self.gif89a, Self.gif87a]
 
 		/// The signature for standard JPEG data.
 		///
@@ -71,26 +73,35 @@ public extension Data {
 		/// JPEG signatures start at byte 6.
 		static let exif = "Exif".data(using: .ascii)!
 
+		/// A convenience array of all JPEG signatures.
+		static let jpeg = [Self.jfif, Self.exif]
+	}
+
+	private func matchesSignature(from signatures: [Data], at offset: Int = 0) -> Bool {
+		for signature in signatures {
+			let upperBound = signature.count + offset
+
+			if upperBound < count, self[offset..<upperBound] == signature {
+				return true
+			}
+		}
+
+		return false
 	}
 
 	/// Returns `true` if the data begins with the PNG signature.
 	var isPNG: Bool {
-		return prefix(8) == ImageSignature.png
+		return matchesSignature(from: [ImageSignature.png])
 	}
 
 	/// Returns `true` if the data begins with a valid GIF signature.
 	var isGIF: Bool {
-		let prefix = self.prefix(6)
-		return prefix == ImageSignature.gif89a || prefix == ImageSignature.gif87a
+		return matchesSignature(from: ImageSignature.gif)
 	}
 
 	/// Returns `true` if the data contains a valid JPEG signature.
 	var isJPEG: Bool {
-		if count < 10 {
-			return false
-		}
-		let signature = self[6..<10]
-		return signature == ImageSignature.jfif || signature == ImageSignature.exif
+		return matchesSignature(from: ImageSignature.jpeg, at: 6)
 	}
 
 	/// Returns `true` if the data is an image (PNG, JPEG, or GIF).

--- a/RSCore/Data+RSCore.swift
+++ b/RSCore/Data+RSCore.swift
@@ -90,7 +90,7 @@ public extension Data {
 		return matchesSignature(from: [ImageSignature.gif89a, ImageSignature.gif87a])
 	}
 
-	/// Returns `true` if the data contains a valid JPEG signature.
+	/// Returns `true` if the data begins with a valid JPEG signature.
 	var isJPEG: Bool {
 		return matchesSignature(from: [ImageSignature.jpeg])
 	}

--- a/RSCore/Data+RSCore.swift
+++ b/RSCore/Data+RSCore.swift
@@ -55,26 +55,15 @@ public extension Data {
 		///
 		/// [http://www.onicos.com/staff/iz/formats/gif.html](http://www.onicos.com/staff/iz/formats/gif.html)
 		static let gif89a = "GIF89a".data(using: .ascii)!
+
 		/// The signature for GIF 87a data.
 		///
 		/// [http://www.onicos.com/staff/iz/formats/gif.html](http://www.onicos.com/staff/iz/formats/gif.html)
 		static let gif87a = "GIF87a".data(using: .ascii)!
 
-		/// A convenience array of all GIF signatures.
-		static let gif = [Self.gif89a, Self.gif87a]
+		/// The signature for JPEG data.
+		static let jpeg = Data([0xFF, 0xD8, 0xFF])
 
-		/// The signature for standard JPEG data.
-		///
-		/// JPEG signatures start at byte 6.
-		static let jfif = "JFIF".data(using: .ascii)!
-
-		/// The signature for Exif JPEG data.
-		///
-		/// JPEG signatures start at byte 6.
-		static let exif = "Exif".data(using: .ascii)!
-
-		/// A convenience array of all JPEG signatures.
-		static let jpeg = [Self.jfif, Self.exif]
 	}
 
 	/// Check if data matches a signature at a particular offset.
@@ -83,11 +72,11 @@ public extension Data {
 	///   - signatures: An array of signatures to match against.
 	///   - offset: The offset into `self` to check for a match.
 	/// - Returns: `true` if the data matches; `false` otherwise.
-	private func matchesSignature(from signatures: [Data], at offset: Int = 0) -> Bool {
+	private func matchesSignature(from signatures: [Data]) -> Bool {
 		for signature in signatures {
-			let upperBound = signature.count + offset
+			let upperBound = signature.count
 
-			if upperBound < count, self[offset..<upperBound] == signature {
+			if upperBound < count, self[..<upperBound] == signature {
 				return true
 			}
 		}
@@ -102,12 +91,12 @@ public extension Data {
 
 	/// Returns `true` if the data begins with a valid GIF signature.
 	var isGIF: Bool {
-		return matchesSignature(from: ImageSignature.gif)
+		return matchesSignature(from: [ImageSignature.gif89a, ImageSignature.gif87a])
 	}
 
 	/// Returns `true` if the data contains a valid JPEG signature.
 	var isJPEG: Bool {
-		return matchesSignature(from: ImageSignature.jpeg, at: 6)
+		return matchesSignature(from: [ImageSignature.jpeg])
 	}
 
 	/// Returns `true` if the data is an image (PNG, JPEG, or GIF).

--- a/RSCoreTests/Data+RSCoreTests.swift
+++ b/RSCoreTests/Data+RSCoreTests.swift
@@ -100,8 +100,9 @@ class Data_RSCoreTests: XCTestCase {
 		XCTAssertTrue(gifData.isImage)
 	}
 
-	func testDataIsTooSmallForJPEG() {
-		let data = Data(count: 9)
+	// Shouldn't crash.
+	func testDataIsTooSmall() {
+		let data = Data(count: 2)
 		XCTAssertFalse(data.isJPEG)
 	}
 


### PR DESCRIPTION
This fixes a few small style/correctness issues:

- Changes the signature constants created from strings to be non-optional.
- Uses the first three bytes (`0xFF`, `0xD8`, `0xFF`) to determine whether a file is a JPEG, instead of looking for `"JFIF"` or `"Exif"` in the extension segment (i.e., at offset 6). (`0xFF` isn't a valid UTF-8 byte.)
    - (I came across a JPEG file that was neither JFIF or Exif, though these are pretty rare.)
- Funnels the checks through a `matchesSignature(from:)` function.

