### PR TITLE
Conditionally compile the CryptoKit calls so we can build on Mojave

### DIFF
--- a/RSCore/Data+RSCore.swift
+++ b/RSCore/Data+RSCore.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
-//#if canImport(CryptoKit)
-//import CryptoKit
-//#endif
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
 import CommonCrypto
 
 public extension Data {
@@ -17,20 +17,30 @@ public extension Data {
 	/// The MD5 hash of the data.
 	var md5Hash: Data {
 
-//		if #available(macOS 10.15, *) {
-//			let digest = Insecure.MD5.hash(data: self)
-//			return Data(digest)
-//		} else {
-			let len = Int(CC_MD5_DIGEST_LENGTH)
-			let md = UnsafeMutablePointer<CUnsignedChar>.allocate(capacity: len)
+		#if canImport(CryptoKit)
+		if #available(macOS 10.15, *) {
+			let digest = Insecure.MD5.hash(data: self)
+			return Data(digest)
+		} else {
+			return ccMD5Hash
+		}
+		#else
+		return ccMD5Hash
+		#endif
 
-			let _ = self.withUnsafeBytes {
-				CC_MD5($0.baseAddress, numericCast($0.count), md)
-			}
+	}
 
-			return Data(bytes: md, count: len)
-//		}
+	@available(macOS, deprecated: 10.15)
+	@available(iOS, deprecated: 13.0)
+	private var ccMD5Hash: Data {
+		let len = Int(CC_MD5_DIGEST_LENGTH)
+		let md = UnsafeMutablePointer<CUnsignedChar>.allocate(capacity: len)
 
+		let _ = self.withUnsafeBytes {
+			CC_MD5($0.baseAddress, numericCast($0.count), md)
+		}
+
+		return Data(bytes: md, count: len)
 	}
 
 	/// The MD5 has of the data, as a hexadecimal string.


### PR DESCRIPTION
...without iOS 13 throwing deprecation errors.

This should make RSCore build on 10.14 without needing to comment all the CryptoKit stuff out.

I don't have a 10.14 machine to test on, so I'd be grateful if someone else could do so.