### PR TITLE
Quiet warnings about class-constrained protocol

### DIFF
--- a/Sources/RSCore/AppKit/KeyboardDelegateProtocol.swift
+++ b/Sources/RSCore/AppKit/KeyboardDelegateProtocol.swift
@@ -10,7 +10,7 @@ import AppKit
 
 //let keypadEnter: unichar = 3
 
-@objc public protocol KeyboardDelegate: class {
+@objc public protocol KeyboardDelegate: AnyObject {
 	
 	// Return true if handled.
 	func keydown(_: NSEvent, in view: NSView) -> Bool

--- a/Sources/RSCore/CloudKit/CloudKitZone.swift
+++ b/Sources/RSCore/CloudKit/CloudKitZone.swift
@@ -26,13 +26,13 @@ public enum CloudKitZoneError: LocalizedError {
 	}
 }
 
-public protocol CloudKitZoneDelegate: class {
+public protocol CloudKitZoneDelegate: AnyObject {
 	func cloudKitDidModify(changed: [CKRecord], deleted: [CloudKitRecordKey], completion: @escaping (Result<Void, Error>) -> Void);
 }
 
 public typealias CloudKitRecordKey = (recordType: CKRecord.RecordType, recordID: CKRecord.ID)
 
-public protocol CloudKitZone: class {
+public protocol CloudKitZone: AnyObject {
 	
 	static var qualityOfService: QualityOfService { get }
 

--- a/Sources/RSCore/Shared/MainThreadOperation.swift
+++ b/Sources/RSCore/Shared/MainThreadOperation.swift
@@ -15,7 +15,7 @@ import Foundation
 /// When it’s canceled, it should do its best to stop
 /// doing whatever it’s doing. However, it should not
 /// leave data in an inconsistent state.
-public protocol MainThreadOperation: class {
+public protocol MainThreadOperation: AnyObject {
 
 	// These three properties are set by MainThreadOperationQueue. Don’t set them.
 	var isCanceled: Bool { get set } // Check this at appropriate times in case the operation has been canceled.

--- a/Sources/RSCore/Shared/MainThreadOperationQueue.swift
+++ b/Sources/RSCore/Shared/MainThreadOperationQueue.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol MainThreadOperationDelegate: class {
+public protocol MainThreadOperationDelegate: AnyObject {
 	func operationDidComplete(_ operation: MainThreadOperation)
 	func cancelOperation(_ operation: MainThreadOperation)
 	func make(_ childOperation: MainThreadOperation, dependOn parentOperation: MainThreadOperation)

--- a/Sources/RSCore/Shared/UndoableCommand.swift
+++ b/Sources/RSCore/Shared/UndoableCommand.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol UndoableCommand: class {
+public protocol UndoableCommand: AnyObject {
 
 	var undoActionName: String { get }
 	var redoActionName: String { get }
@@ -39,7 +39,7 @@ extension UndoableCommand {
 
 // Useful for view controllers.
 
-public protocol UndoableCommandRunner: class {
+public protocol UndoableCommandRunner: AnyObject {
     
     var undoableCommands: [UndoableCommand] { get set }
     var undoManager: UndoManager? { get }


### PR DESCRIPTION
Quiet warnings that were being generated: "Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead"
