### PR TITLE
Fixed clipped toolbar items are always disabled on macOS

### DIFF
--- a/Sources/RSCore/AppKit/RSToolbarItem.swift
+++ b/Sources/RSCore/AppKit/RSToolbarItem.swift
@@ -12,54 +12,20 @@ public class RSToolbarItem: NSToolbarItem {
 
 	override public func validate() {
 
-		guard let view = view, let _ = view.window else {
+		guard let control = self.view as? NSControl, let action = self.action,
+			  let validator = NSApp.target(forAction: action, to: self.target, from: self) as AnyObject? else {
+
 			isEnabled = false
 			return
 		}
-		isEnabled = isValidAsUserInterfaceItem()
-	}
-}
 
-private extension RSToolbarItem {
-
-	func isValidAsUserInterfaceItem() -> Bool {
-
-		// Use NSValidatedUserInterfaceItem protocol rather than calling validateToolbarItem:.
-
-		if let target = target as? NSResponder {
-			return validateWithResponder(target) ?? false
+		// Prefer `NSUserInterfaceValidations` protocol over calling `validateToolbarItem`.
+		switch validator {
+		case let validator as NSUserInterfaceValidations:
+			control.isEnabled = validator.validateUserInterfaceItem(self)
+		default:
+			control.isEnabled = validator.validateToolbarItem(self)
 		}
-
-		var responder = view?.window?.firstResponder
-		if responder == nil {
-			return false
-		}
-
-		while(true) {
-			if let validated = validateWithResponder(responder!) {
-				return validated
-			}
-			responder = responder?.nextResponder
-			if responder == nil {
-				break
-			}
-		}
-
-		if let appDelegate = NSApplication.shared.delegate {
-			if let validated = validateWithResponder(appDelegate) {
-				return validated
-			}
-		}
-
-		return false
-	}
-
-	func validateWithResponder(_ responder: NSObjectProtocol) -> Bool? {
-
-		guard responder.responds(to: action), let target = responder as? NSUserInterfaceValidations else {
-			return nil
-		}
-		return target.validateUserInterfaceItem(self)
 	}
 }
 #endif


### PR DESCRIPTION
The validation now also takes clipped items into account and defaults to `validateToolbarItem` if `NSUserInterfaceValidations` is not available.